### PR TITLE
Add GitHub token to gitleaks workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,7 @@ jobs:
           log-level: warn
           redact: true
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- supply the built-in GitHub Actions token to the existing gitleaks step so the scan can authenticate with the API

## Background
The gitleaks action fails without `GITHUB_TOKEN` because it calls the GitHub API when it reports findings. Adding the token keeps the scan running and lets it continue leaving review comments when it finds potential secrets.

## Testing
- not run (workflow only)

@CivicTechWR/organizers please review.
