### PR TITLE
docs: refresh primary readme

### DIFF
--- a/.github/workflows/reusable-gitleaks.yml
+++ b/.github/workflows/reusable-gitleaks.yml
@@ -10,7 +10,7 @@ on:
       response_guide_url:
         type: string
         required: false
-        default: https://github.com/CivicTechWR/.github/blob/main/docs/gitleaks-response.md
+        default: https://github.com/CivicTechWR/go-train-group-pass/blob/main/docs/gitleaks-response.md
       block_on_findings:
         type: boolean
         required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Go Train Group Pass
+
+We welcome contributions from volunteers of all experience levels. This guide covers how to get plugged into the community, set up your environment, and collaborate effectively on changes.
+
+## Community & Meetings
+
+- **Weekly meetup:** Wednesdays from 6-8pm at Builders Club (165 King St W); remote participation is coordinated through our Luma event listing (placeholder: add current Luma link).
+- **RSVP & calendar:** Keep an eye on [our Meetup page](https://www.meetup.com/civictechwr/) for session topics, schedule changes, and reminders.
+- **Hybrid participation:** If you cannot attend in person, drop a note in Slack so we can arrange dial-in details when available.
+
+## Communication Channels
+
+- **Slack:** Join via [this invite link](https://join.slack.com/t/civictechwr/shared_invite/zt-2ldijjy0i-gaGvPkuafPt9Zpn7jml70w) and head straight to `#project-go-train-group-pass` for project updates and pairing requests.
+- **Sensitive matters:** Email `civictechwr@gmail.com` for anything that should not live in public channels or GitHub issues.
+- **GitHub issues:** Use issue templates for bugs, features, and project questions so maintainers can triage quickly.
+
+## Development Environment
+
+Our active code lives in the `backend/` directory. To contribute effectively:
+
+- Install **Node.js v18+** and **npm v9+** (or newer). We recommend using `nvm` or a similar version manager to stay aligned with CI.
+- Install the **Supabase CLI** and **Docker** to run the local database and auth stack. Follow the step-by-step instructions in [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md).
+- Initialize the backend by following [`backend/README.md#getting-started`](backend/README.md#getting-started) for environment variables, migrations, and local commands.
+- Run `npm run start:dev` from `backend/` for the API, and keep `npm run lint`, `npm run type-check`, and `npm run test` handy before opening a pull request.
+
+## Contribution Workflow
+
+1. **Pick or propose work:** Comment on an open issue or create a new one using the templates in `.github/ISSUE_TEMPLATE/`.
+2. **Create a branch:** Use a feature branch such as `feature/add-trip-endpoint` or `fix/auth-timeout`.
+3. **Build iteratively:** Commit early and often, keeping changes scoped so they are reviewable.
+4. **Check quality gates:** Lint, type-check, and run relevant tests (`npm run test`, `npm run test:e2e`) before pushing.
+5. **Open a pull request:** Reference the issue, describe the change, and complete the PR checklist.
+
+## Semantic Commit Messages
+
+We follow conventional, semantic commit messages to keep the history clean and to power automated tooling.
+
+```text
+type(scope?): short summary in present tense
+```
+
+Common types include:
+
+- `feat`: new user-facing functionality
+- `fix`: bug fixes or behavior corrections
+- `docs`: documentation-only changes
+- `style`: code formatting or cosmetic updates without logic changes
+- `refactor`: restructuring code without changing behavior
+- `test`: adding or updating tests
+- `build`: build system or dependency changes
+- `ci`: CI/CD configuration updates
+- `chore`: repository maintenance tasks
+- `revert`: revert a previous commit
+
+Use a scope (e.g., `auth`, `gtfs`, `docs`) when it clarifies the impacted area: `feat(auth): support refreshed tokens`.
+
+## Pull Request Expectations
+
+- Keep PRs focused; split large efforts into a series of smaller, reviewable changes when possible.
+- Include screenshots or API examples when the change affects user-facing behavior or contract surfaces.
+- Note any follow-up tasks or known gaps so maintainers can plan the next iteration.
+- Flag migrations or Supabase changes in the PR checklist to alert reviewers of operational impacts.
+
+## Reporting Security or Privacy Concerns
+
+If you discover a potential security vulnerability or sensitive data exposure, avoid filing a public issue. Instead, email `civictechwr@gmail.com` with the details so maintainers can coordinate a response.
+
+## Additional Resources
+
+- [`README.md`](README.md) for project overview and quick links to product specs
+- [`backend/README.md`](backend/README.md) for detailed API setup, scripts, and project structure
+- [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md) for database and auth infrastructure parity
+
+Thanks for contributing to CivicTechWR and helping riders travel together more easily!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ We welcome contributions from volunteers of all experience levels. This guide co
 
 ## Community & Meetings
 
-- **Weekly meetup:** Wednesdays from 6-8pm at Builders Club (165 King St W); remote participation is coordinated through our Luma event listing (placeholder: add current Luma link).
-- **RSVP & calendar:** Keep an eye on [our Meetup page](https://www.meetup.com/civictechwr/) for session topics, schedule changes, and reminders.
+- **Weekly meetup:** Wednesdays from 6-8pm at Builders Club (165 King St W).
+- **RSVP & calendar:** Keep an eye on [our Meetup page](https://www.meetup.com/civictechwr/) or the Luma listing (placeholder: add current Luma link) for session topics, schedule changes, and reminders.
 - **Hybrid participation:** If you cannot attend in person, drop a note in Slack so we can arrange dial-in details when available.
 
 ## Communication Channels

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ Go Train Group Pass is a civic-tech collaboration that streamlines the purchase 
 - [Technical Design Document (Notion, WIP)](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43)
 - [Product and UX boards (Figma)](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1)
 
+### Product Principles
+
+- **Support stewards, not replace them:** The app augments the existing steward-led process and does not referee peer-to-peer payments.
+- **Time-sensitive coordination:** Push notifications and real-time status cues are core to keeping the group aligned in the minutes leading up to boarding and while on the train.
+- **Clarity over chat scrollback:** Interfaces focus on surfacing the current itinerary state rather than relying on ad-hoc messaging threads.
+
+### Rider Journey Stages
+
+The system models the real-world coordination stages outlined in the design document:
+
+1. **Pre-planning:** Riders signal interest in an outbound/return itinerary and nominate potential stewards.
+2. **Pre-board:** Final group formation happens ~5 minutes before departure as stewards purchase and share pass details.
+3. **On board:** Riders may be seated apart; quick regrouping and proof-of-purchase handling (e.g., for fare inspections) is essential.
+4. **Post board:** Stewards reconcile payments (e-transfers today) and capture participation outcomes for the return leg.
+
 ```mermaid
 flowchart LR
     subgraph Riders
@@ -75,6 +90,7 @@ For a breakdown of directories, rely on [`backend/README.md#project-structure`](
 - GTFS data ingestion and exposure via MikroORM entities for agencies, routes, stops, trips, and service calendars (`backend/src/entities`).
 - Continuous integration pipelines covering linting, accessibility smoke tests, and security scans (see badges above).
 - Local-first workflow powered by Supabase CLI to mirror production infrastructure (`backend/SUPABASE_SETUP.md`).
+- Product foundations aligned to the technical design document, including itinerary concepts (trip + return), steward/passenger roles, and notification hooks for each journey stage.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Go Train Group Pass is a civic-tech collaboration that streamlines the purchase and coordination of GO Transit group passes. The platform exposes authenticated APIs, GTFS-powered data services, and admin tools that downstream web or mobile clients use to help riders plan trips, manage eligibility, and share passes across a group.
 
-- [Technical Design Document (Notion, WIP)](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43)
+- [Technical Design Document (Notion, WIP)](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9)
 - [Product and UX boards (Figma)](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1)
 
 ### Product Principles
@@ -61,7 +61,7 @@ Reference: `backend/package.json` and [`backend/README.md`](backend/README.md#te
 
 ## Architecture Overview
 
-- High level diagram: see Mermaid chart above or the [architecture callout in Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43).
+- High-level flow: the Mermaid chart above captures rider, platform, and Supabase interactions. The broader MVP coordination stages live in the Technical Design Document linked in the Product Overview.
 - Backend modules and entities are documented in [`backend/README.md`](backend/README.md#project-structure) and [`backend/AUTH_SETUP.md`](backend/AUTH_SETUP.md#architecture).
 - Supabase infrastructure and local parity live in [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md).
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Go Train Group Pass is a civic-tech collaboration that streamlines the purchase 
 
 ### Rider Journey Stages
 
-The system models the real-world coordination stages outlined in the design document:
+The product vision spans four coordination stages captured in the Notion design brief. The current MVP focuses on the in-progress phases while the bookend steps remain in discovery:
 
-1. **Pre-planning:** Riders signal interest in an outbound/return itinerary and nominate potential stewards.
-2. **Pre-board:** Final group formation happens ~5 minutes before departure as stewards purchase and share pass details.
-3. **On board:** Riders may be seated apart; quick regrouping and proof-of-purchase handling (e.g., for fare inspections) is essential.
-4. **Post board:** Stewards reconcile payments (e-transfers today) and capture participation outcomes for the return leg.
+1. **Pre-board (MVP):** Final group formation happens minutes before departure as stewards purchase and share pass details.
+2. **On board (MVP):** Riders may be seated apart; quick regrouping and proof-of-purchase handling (e.g., fare inspections) is essential.
+3. **Pre-planning (Future):** Riders signal interest in outbound or return itineraries and nominate potential stewards.
+4. **Post board (Future):** Stewards reconcile payments and capture participation outcomes for the return leg.
 
 ```mermaid
 flowchart LR
@@ -56,6 +56,7 @@ flowchart LR
 - **Backend:** NestJS 11 (Fastify adapter), TypeScript, MikroORM (PostgreSQL)
 - **Authentication:** Supabase Auth (JWT session tokens)
 - **Data Source:** GO Transit GTFS feeds mapped into Supabase PostgreSQL 17
+- **Frontend (planned):** Next.js + React web client (currently in discovery; implementation will land in a dedicated frontend workspace)
 - **Tooling:** ESLint, Prettier, Vitest, SWC, ts-node
 - **Automation:** GitHub Actions for linting, accessibility audits, and security scans
 
@@ -90,7 +91,7 @@ Follow the guide for the area you plan to work on:
 
 - Account creation and authentication so riders and stewards can sign in securely.
 - Itinerary and schedule data modeled from GO Transit GTFS feeds to anchor trip planning conversations.
-- Steward-centric flows in the backend (sign-up, session management, upcoming itinerary endpoints) that support the `pre-planning → post-board` journey.
+- Steward-centric flows in the backend (sign-up, session management, upcoming itinerary endpoints) that support day-of coordination (`pre-board` and `on-board` stages).
 
 ### In Flight
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Accessibility Audit](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/accessibility.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/accessibility.yml)
 [![Security Audit](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/security.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/security.yml)
 
+Interested in helping out? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for meetup details, setup steps, and collaboration norms.
+
 ## Product Overview
 
 Go Train Group Pass is a civic-tech collaboration that streamlines the purchase and coordination of GO Transit group passes. The platform exposes authenticated APIs, GTFS-powered data services, and admin tools that downstream web or mobile clients use to help riders plan trips, manage eligibility, and share passes across a group.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# Go Train Group Pass
+
+[![Lint and Type Check](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/lint.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/lint.yml)
+[![Accessibility Audit](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/accessibility.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/accessibility.yml)
+[![Security Audit](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/security.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/security.yml)
+
+## Product Overview
+
+Go Train Group Pass is a civic-tech collaboration that streamlines the purchase and coordination of GO Transit group passes. The platform exposes authenticated APIs, GTFS-powered data services, and admin tools that downstream web or mobile clients use to help riders plan trips, manage eligibility, and share passes across a group.
+
+- [Technical Design Document (Notion, WIP)](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43)
+- [Product and UX boards (Figma)](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1)
+
+```mermaid
+flowchart LR
+    subgraph Riders
+        EndUsers[Group riders]
+    end
+    subgraph CivicTechWR Platform
+        Clients[Web & future mobile apps]
+        API[NestJS + Fastify API]
+        AuthGuard[Supabase Auth integration]
+        Data[GTFS + Pass entities]
+    end
+    subgraph Infrastructure
+        SupabaseAuth[Supabase Auth]
+        SupabaseDB[Supabase PostgreSQL]
+    end
+
+    EndUsers --> Clients --> API
+    API --> AuthGuard
+    AuthGuard --> SupabaseAuth
+    API --> Data --> SupabaseDB
+    SupabaseAuth --> SupabaseDB
+```
+
+## Technology Stack
+
+- **Backend:** NestJS 11 (Fastify adapter), TypeScript, MikroORM (PostgreSQL)
+- **Authentication:** Supabase Auth (JWT session tokens)
+- **Data Source:** GO Transit GTFS feeds mapped into Supabase PostgreSQL 17
+- **Tooling:** ESLint, Prettier, Vitest, SWC, ts-node
+- **Automation:** GitHub Actions for linting, accessibility audits, and security scans
+
+Reference: `backend/package.json` and [`backend/README.md`](backend/README.md#tech-stack).
+
+## Architecture Overview
+
+- High level diagram: see Mermaid chart above or the [architecture callout in Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43).
+- Backend modules and entities are documented in [`backend/README.md`](backend/README.md#project-structure) and [`backend/AUTH_SETUP.md`](backend/AUTH_SETUP.md#architecture).
+- Supabase infrastructure and local parity live in [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md).
+
+## Getting Started
+
+Follow the guide for the area you plan to work on:
+
+| Surface            | Status       | Setup Guide                                                                                                                                                    |
+| ------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backend API        | Active       | [`backend/README.md#getting-started`](backend/README.md#getting-started)                                                                                       |
+| Supabase stack     | Active       | [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md)                                                                                                       |
+| Frontend (Next.js) | In discovery | Track progress in [Figma board](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) and forthcoming docs |
+
+## Project Structure
+
+- Back-end service lives in [`backend/`](backend/) with NestJS modules, MikroORM configs, and Vitest suites.
+- Infrastructure configuration is collected in [`supabase/`](supabase/).
+- CI/CD automations sit in [`.github/workflows/`](.github/workflows/).
+- UX, documentation, and product planning assets reside externally in [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1).
+
+For a breakdown of directories, rely on [`backend/README.md#project-structure`](backend/README.md#project-structure) to avoid duplicating the source of truth.
+
+## Key Features
+
+- Supabase-authenticated REST API for rider sign-up, authentication, and session management ([`backend/AUTH_SETUP.md`](backend/AUTH_SETUP.md)).
+- GTFS data ingestion and exposure via MikroORM entities for agencies, routes, stops, trips, and service calendars (`backend/src/entities`).
+- Continuous integration pipelines covering linting, accessibility smoke tests, and security scans (see badges above).
+- Local-first workflow powered by Supabase CLI to mirror production infrastructure (`backend/SUPABASE_SETUP.md`).
+
+## Development Workflow
+
+- Work from feature branches aligned with the contribution templates in [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) and [`pull_request_template.md`](.github/pull_request_template.md).
+- Automated checks run on every push/PR; monitor the GitHub Action badges or run equivalents locally (`npm run lint`, `npm run type-check`, `npm run test`).
+- Consult the [Notion workflow analysis section](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c0080c0beaa576dc85df8ba) for sprint cadence and release planning.
+
+## Coding Standards
+
+- Style and linting rules are defined in `backend/.eslintrc.json` and enforced through `npm run lint` (see [`backend/README.md#code-quality`](backend/README.md#code-quality)).
+- Formatting relies on Prettier; use `npm run format` / `npm run format:check`.
+- Domain-driven patterns and DTO validation details live in the corresponding backend documentation sections to reduce duplication.
+
+## Testing
+
+- A full overview of unit, integration, e2e, coverage, and accessibility testing lives in [`backend/README.md#testing`](backend/README.md#testing) and the associated scripts (`package.json`).
+- CI executes the same commands, including accessibility audits via Playwright + axe (`npm run test:a11y`) and scheduled security scans.
+
+## Contributing
+
+- Review the [Notion product roadmap](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) and [Figma flows](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) for context before drafting solutions.
+- Use the issue templates to capture requirements; follow the pull-request checklist to surface tests, migrations, and Supabase changes.
+- Reference code patterns in `backend/src` and examples in future `docs/` entries rather than duplicating snippets here, keeping the README evergreen.
+
+## License
+
+This repository does not yet declare a license. Coordinate with CivicTechWR maintainers before using the code outside the project.

--- a/README.md
+++ b/README.md
@@ -77,20 +77,24 @@ Follow the guide for the area you plan to work on:
 
 ## Project Structure
 
-- Back-end service lives in [`backend/`](backend/) with NestJS modules, MikroORM configs, and Vitest suites.
-- Infrastructure configuration is collected in [`supabase/`](supabase/).
-- CI/CD automations sit in [`.github/workflows/`](.github/workflows/).
-- UX, documentation, and product planning assets reside externally in [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1).
-
-For a breakdown of directories, rely on [`backend/README.md#project-structure`](backend/README.md#project-structure) to avoid duplicating the source of truth.
+- **`backend/`** — NestJS application modules, MikroORM entities, and Vitest suites. See [`backend/README.md#project-structure`](backend/README.md#project-structure) for file-level detail.
+- **`supabase/`** — Local Supabase configuration (CLI, database, auth) that mirrors hosted infrastructure.
+- **`.github/workflows/`** — Automation pipelines for linting, accessibility, and security checks that gate pull requests.
+- **UX & product specs** — Living documents in [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) capture workflows and visual design decisions that have not yet landed in this repo.
 
 ## Key Features
 
+**User-facing foundations (current scope):**
+
 - Supabase-authenticated REST API for rider sign-up, authentication, and session management ([`backend/AUTH_SETUP.md`](backend/AUTH_SETUP.md)).
-- GTFS data ingestion and exposure via MikroORM entities for agencies, routes, stops, trips, and service calendars (`backend/src/entities`).
+- GTFS-backed itinerary modeling (agencies, routes, stops, trips, service calendars) to support the `pre-planning → post-board` journey.
+
+**Developer platform:**
+
 - Continuous integration pipelines covering linting, accessibility smoke tests, and security scans (see badges above).
 - Local-first workflow powered by Supabase CLI to mirror production infrastructure (`backend/SUPABASE_SETUP.md`).
-- Product foundations aligned to the technical design document, including itinerary concepts (trip + return), steward/passenger roles, and notification hooks for each journey stage.
+
+Upcoming feature work, including richer steward tooling and front-end experiences, is tracked in the [Technical Design Document](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9).
 
 ## Development Workflow
 
@@ -102,6 +106,7 @@ For a breakdown of directories, rely on [`backend/README.md#project-structure`](
 
 - Style and linting rules are defined in `backend/.eslintrc.json` and enforced through `npm run lint` (see [`backend/README.md#code-quality`](backend/README.md#code-quality)).
 - Formatting relies on Prettier; use `npm run format` / `npm run format:check`.
+- All pull requests must pass the GitHub workflows (lint, accessibility, security) before merging.
 - Domain-driven patterns and DTO validation details live in the corresponding backend documentation sections to reduce duplication.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Go Train Group Pass is a civic-tech collaboration that streamlines the purchase 
 ### Product Principles
 
 - **Support stewards, not replace them:** The app augments the existing steward-led process and does not referee peer-to-peer payments.
-- **Time-sensitive coordination:** Push notifications and real-time status cues are core to keeping the group aligned in the minutes leading up to boarding and while on the train.
+- **Time-sensitive coordination:** Clear status cues are core to keeping the group aligned in the minutes leading up to boarding and while on the train.
 - **Clarity over chat scrollback:** Interfaces focus on surfacing the current itinerary state rather than relying on ad-hoc messaging threads.
 
 ### Rider Journey Stages
 
-The product vision spans four coordination stages captured in the Notion design brief. The current MVP focuses on the in-progress phases while the bookend steps remain in discovery:
+The stages below map to open issues in this repository:
 
-1. **Pre-board (MVP):** Final group formation happens minutes before departure as stewards purchase and share pass details.
-2. **On board (MVP):** Riders may be seated apart; quick regrouping and proof-of-purchase handling (e.g., fare inspections) is essential.
-3. **Pre-planning (Future):** Riders signal interest in outbound or return itineraries and nominate potential stewards.
-4. **Post board (Future):** Stewards reconcile payments and capture participation outcomes for the return leg.
+1. **Pre-board (MVP):** Group formation, check-in, QR/scan, and steward confirmations ([#67–71](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+67..71), [#93–100](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+93..100), [#104–110](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+104..110)).
+2. **On board (MVP):** Steward tools for verification and regrouping (same issue sets as above).
+3. **Pre-planning (Planned):** Trip search and itinerary creation ([#64–66](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+64..66), [#74–86](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+74..86)).
+4. **Post board (Planned):** Ticket purchase, cost splits, and payments/reconciliation ([#72–73](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+72..73), [#107–115](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+107..115)).
 
 ```mermaid
 flowchart LR
@@ -56,7 +56,7 @@ flowchart LR
 - **Backend:** NestJS 11 (Fastify adapter), TypeScript, MikroORM (PostgreSQL)
 - **Authentication:** Supabase Auth (JWT session tokens)
 - **Data Source:** GO Transit GTFS feeds mapped into Supabase PostgreSQL 17
-- **Frontend (planned):** Next.js + React web client (currently in discovery; implementation will land in a dedicated frontend workspace)
+- **Frontend (planned):** Next.js + React web client (see issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52))
 - **Tooling:** ESLint, Prettier, Vitest, SWC, ts-node
 - **Automation:** GitHub Actions for linting, accessibility audits, and security scans
 
@@ -76,7 +76,7 @@ Follow the guide for the area you plan to work on:
 | ------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Backend API        | Active       | [`backend/README.md#getting-started`](backend/README.md#getting-started)                                                                                       |
 | Supabase stack     | Active       | [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md)                                                                                                       |
-| Frontend (Next.js) | In discovery | Track progress in [Figma board](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) and forthcoming docs |
+| Frontend (Next.js) | Planned      | Track via issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52); setup docs will follow |
 
 ## Project Structure
 
@@ -87,19 +87,21 @@ Follow the guide for the area you plan to work on:
 
 ## Key Features
 
-### Current Capabilities
+### Current state (in repo)
 
-- Account creation and authentication so riders and stewards can sign in securely.
-- Itinerary and schedule data modeled from GO Transit GTFS feeds to anchor trip planning conversations.
-- Steward-centric flows in the backend (sign-up, session management, upcoming itinerary endpoints) that support day-of coordination (`pre-board` and `on-board` stages).
+- Supabase-authenticated REST endpoints for signup/signin/refresh/password flows (`backend/src/auth`).
+- GTFS data models defined via MikroORM entities (`backend/src/entities`), ready for ingestion and API layers.
+- CI workflows for linting, accessibility smoke tests, and security scans (see badges above).
 
-### In Flight
+### Planned/backlog (open issues)
 
-- Guided UI flows for each journey stage with context-aware push notifications.
-- Steward workspace to share proof-of-purchase, confirm rider check-ins, and track reimbursements.
-- Rider-facing status views including a lightweight schedule viewer and reminders for boarding and regrouping moments.
+- Trip search and itinerary creation APIs: [#64–66](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+64..66), [#74–86](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+74..86)
+- Group formation, check-in, steward views, QR/scan, and confirmations: [#67–71](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+67..71), [#93–100](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+93..100), [#104–110](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+104..110)
+- Ticket purchase, cost split, payments, and mark-paid flows: [#72–73](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+72..73), [#107–115](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+107..115)
+- GTFS ingestion and schedule import: [#3](https://github.com/CivicTechWR/go-train-group-pass/issues/3), [#13](https://github.com/CivicTechWR/go-train-group-pass/issues/13)
+- Frontend Next.js/React app and hosting decisions: [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26), [#27](https://github.com/CivicTechWR/go-train-group-pass/issues/27), [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)
 
-Refer to the [Technical Design Document](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) for the full backlog and target experience.
+Refer to the [Technical Design Document](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) for the broader roadmap; keep the README aligned with open issues when adding new commitments.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -84,17 +84,19 @@ Follow the guide for the area you plan to work on:
 
 ## Key Features
 
-**User-facing foundations (current scope):**
+### Current Capabilities
 
-- Supabase-authenticated REST API for rider sign-up, authentication, and session management ([`backend/AUTH_SETUP.md`](backend/AUTH_SETUP.md)).
-- GTFS-backed itinerary modeling (agencies, routes, stops, trips, service calendars) to support the `pre-planning → post-board` journey.
+- Account creation and authentication so riders and stewards can sign in securely.
+- Itinerary and schedule data modeled from GO Transit GTFS feeds to anchor trip planning conversations.
+- Steward-centric flows in the backend (sign-up, session management, upcoming itinerary endpoints) that support the `pre-planning → post-board` journey.
 
-**Developer platform:**
+### In Flight
 
-- Continuous integration pipelines covering linting, accessibility smoke tests, and security scans (see badges above).
-- Local-first workflow powered by Supabase CLI to mirror production infrastructure (`backend/SUPABASE_SETUP.md`).
+- Guided UI flows for each journey stage with context-aware push notifications.
+- Steward workspace to share proof-of-purchase, confirm rider check-ins, and track reimbursements.
+- Rider-facing status views including a lightweight schedule viewer and reminders for boarding and regrouping moments.
 
-Upcoming feature work, including richer steward tooling and front-end experiences, is tracked in the [Technical Design Document](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9).
+Refer to the [Technical Design Document](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) for the full backlog and target experience.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ A: Absolutely! We need designers, testers, writers, and people to help with user
 
 **Q: I’m a beginner, is this project too advanced?**
 
-A: Not at all. We welcome all skill levels. The backend is complex, but we can help you learn. If you’re interested in frontend, we’ll pair you with someone who can guide you.
+A: Not at all. We welcome all skill levels. Every piece of work can be broken down into manageable tasks - we're here to help with that. Whether you're interested in backend, frontend, or other areas, we'll pair you with someone who can guide you.
 
 **Q: What if I can only volunteer occasionally?**
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Interested in helping out? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for m
 
 - Node.js 18+ and npm
 - PostgreSQL (or use our Supabase setup)
-- Basic familiarity with REST APIs
+- Basic familiarity with REST APIs and ORMs (we use MikroORM)
 
 **Get the backend running:**
 

--- a/README.md
+++ b/README.md
@@ -53,77 +53,7 @@ A web app where commuters can:
 
 ## Current Status & Roadmap
 
-### Rider Journey Stages
-
-The stages below map to open issues and our development epics:
-
-#### 1. Pre-planning (Epic 1: Trip Discovery & Planning - 70% done)
-
-Search schedules, create itineraries, plan your trips
-
-- ✅ GTFS data import and refresh
-- ✅ One-way trip schedule search
-- ✅ Round-trip Kitchener-Union query
-- 🔄 Generic round-trip endpoint
-- 🔄 Itinerary creation flow
-- Issues: [#64–66](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+64..66), [#74–86](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+74..86)
-
-#### 2. Pre-board - MVP Priority
-
-**Epic 2: Group Formation & Matching (40% done)**  
-**Epic 3: Group Coordination (0% done)**
-
-Group formation, check-in, QR/scan, and steward confirmations
-
-- ✅ Database schema (travel_group, trip_booking)
-- ✅ Group formation background job
-- 🔄 Manual group formation trigger
-- ❌ Group chat/messaging
-- ❌ Meetup location selection
-- ❌ Member check-in status
-- ❌ **Frontend interface** (blocking everything)
-- Issues: [#67–71](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+67..71), [#93–100](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+93..100), [#104–110](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+104..110)
-
-#### 3. On board - MVP Priority
-
-**Epic 3: Group Coordination (continued)**
-
-Steward tools for verification and regrouping
-
-- ❌ Active pass display
-- ❌ Real-time group status
-- ❌ Steward broadcast tools
-- Issues: Same as Pre-board
-
-#### 4. Post board
-
-**Epic 4: Pass Purchase & Activation (20% done)**  
-**Epic 5: Payment Settlement (0% done)**
-
-Ticket purchase, cost splits, and payments/reconciliation
-
-- ✅ Database schema (ticket_purchase, payment tables)
-- ❌ Pass purchase workflow
-- ❌ Cost calculation & display
-- ❌ Payment tracking
-- Issues: [#72–73](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+72..73), [#107–115](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+107..115)
-
-### Additional Epics (Not Started)
-
-**Epic 6: Notifications & Alerts (0% done)**
-
-- Trip reminders, group updates, service disruptions
-- Critical for user adoption post-MVP
-
-**Epic 7: User Experience / Frontend (0% done) ⚠️ BLOCKING**
-
-- Web interface - without this, nothing else matters
-- Issues: [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26), [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)
-
-**Epic 8: Safety & Trust (0% done)**
-
-- User verification, reporting, blocking, moderation
-- Can defer to post-MVP but important for scale
+For the latest project status, roadmap, and development progress, see the [Pass Sharing Project](https://github.com/orgs/CivicTechWR/projects/pass-sharing-project).
 
 ### System Architecture
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ A: No, GO Transit’s weekday group passes are only available as e-tickets, not 
 
 **Q: I’m not a developer, can I still help?**
 
-A: Absolutely! We need designers, testers, writers, and people to help with user research. Come to a hacknight and tell us what you’re interested in.
+A: Absolutely! We need designers, testers, writers, and people to help with user research. Look for issues with the `non-technical` label to find tasks that don't require coding. Come to a hacknight and tell us what you’re interested in.
 
 **Q: I’m a beginner, is this project too advanced?**
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Additional setup guides:
 |------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |Backend API       |Active |[`backend/README.md#getting-started`](backend/README.md#getting-started)                                                                                    |
 |Supabase stack    |Active |[`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md)                                                                                                    |
-|Frontend (Next.js)|Planned|Track via issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)|
+|Frontend (Next.js)|In Progress (on `demoday` branch)|Track via issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)|
 
-**Want to build the frontend?** Talk to us first! We’ll help you:
+**Want to contribute to the frontend?** Talk to us first! We’ll help you:
 
 - Understand the API endpoints
 - Set up your development environment
@@ -101,7 +101,7 @@ Additional setup guides:
 - **`.github/workflows/`** — CI/CD automation pipelines
 - **UX & product specs** — [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1)
 
-Frontend will go in a new folder (we need someone to set it up!)
+Frontend code exists in the `demoday` branch and will be merged soon.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ Read our [Code of Conduct](CODE_OF_CONDUCT.md) and check out [open issues](https
 
 ## Development Workflow
 
+### Issue and PR Management
+
+- **All PRs must be linked to an issue:** We don't merge anything not tied to a ticket. If you start work before creating an issue, add one to the [project board](https://github.com/orgs/CivicTechWR/projects) before opening a PR. This ensures clear tracking of all work without relying solely on commit messages.
+- **One issue per PR:** PRs addressing multiple issues slow down task completion and confuse new contributors who need to work off branches other than main. Keep your PRs focused on a single issue.
+- **PR size and state:** PRs should be in a working state and reasonably sized. While large PRs won't be rejected, smaller PRs are reviewed and merged much faster.
+- **Review requirements:** All PRs must be reviewed before merging.
+
+### Workflow Guidelines
+
 - Work from feature branches aligned with the contribution templates in [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) and [`pull_request_template.md`](.github/pull_request_template.md).
 - Automated checks run on every push/PR; monitor the GitHub Action badges or run equivalents locally (`npm run lint`, `npm run type-check`, `npm run test`).
 - Consult the [Notion workflow analysis section](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c0080c0beaa576dc85df8ba) for sprint cadence and release planning.

--- a/README.md
+++ b/README.md
@@ -115,17 +115,9 @@ Interested in helping out? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for m
 - PostgreSQL (or use our Supabase setup)
 - Basic familiarity with REST APIs and ORMs (we use MikroORM)
 
-**Get the backend running:**
+For backend setup instructions, see the [Backend README](backend/README.md#getting-started).
 
-```bash
-git clone https://github.com/CivicTechWR/go-train-group-pass.git
-cd go-train-group-pass
-npm install
-cd backend
-npm run dev
-```
-
-See detailed setup guides:
+Additional setup guides:
 
 |Surface           |Status |Setup Guide                                                                                                                                                 |
 |------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See detailed setup guides:
 
 ## Project Structure
 
-- **`backend/`** — NestJS application modules, MikroORM entities, and Vitest suites. See [`backend/README.md#project-structure`](backend/README.md#project-structure) for file-level detail.
+- **`backend/`** — Backend API service. See [`backend/README.md#project-structure`](backend/README.md#project-structure) for details.
 - **`packages/shared/`** — Shared TypeScript types and DTOs
 - **`supabase/`** — Local Supabase configuration (CLI, database, auth) that mirrors hosted infrastructure.
 - **`spec/`** — Technical specifications and process documentation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 🚨 We Need Frontend Help
 
-Our backend is built and working, but we have **no user interface yet**. We’re looking for frontend developers (or people willing to learn React/Next.js) to help build the web app. See [Contributing](#contributing) for details.
+Our backend is built and working, but our front end workflows need more work. We’re looking for frontend developers (or people willing to learn React/Next.js) to help build the web app. See [Contributing](#contributing) for details.
 
 -----
 
@@ -308,9 +308,14 @@ A: One person in the group (the “steward”) purchases the pass from GO Transi
 
 ### Privacy & Safety
 
-**Q: What information do other group members see about me?**
+**Q: What information can other people see about me?**
 
-A: By default, only your first name and a profile photo (if you add one). Your phone number and email stay private. Only the ticket steward shares their contact info so the group can coordinate.
+**A:** It depends on your role in a trip.
+
+- **If you’re a group member:** you only see the ticket steward’s contact information. Other group members do not see your contact details.
+- **If you’re the ticket steward:** you can see the names and contact information of the group members for that trip, so you can coordinate.
+
+Everyone keeps a history of past trips. For trips where you were the steward, you’ll retain the contact info for those participants. For trips where you weren’t the steward, you’ll only retain the steward’s contact info.
 
 **Q: What if I get matched with someone I don’t want to travel with?**
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,17 @@ We welcome contributors of all skill levels:
 - **Writers:** Documentation, help content, privacy policies
 - **Anyone interested:** Come learn with us!
 
-### Time Commitment
+### What Commitment Looks Like
 
-- **90-120 minutes/week** at Wednesday hack nights
-- More if you want to contribute outside of meetups
-- Even occasional contributions (once a month) are valuable
+Commitment here is about communication and collaboration, not rigid time requirements. We welcome both regular contributors and one-time contributions:
+
+- **Identify a ticket** you'd like to work on and what you may need to learn
+- **Ask for help** finding resources or getting clarification on unclear requirements
+- **Provide time estimates** when you start work (we include estimates on tickets, but yours may differ based on your familiarity with the codebase and tech)
+- **Communicate updates** to the team, especially if your work is a dependency for something else
+- **Join hack nights** (90-120 minutes/week on Wednesdays) or contribute asynchronously—both work!
+
+Even occasional contributions are valuable. Work at your own pace and communicate openly.
 
 ### Why Join This Project
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,34 @@
-# Go Train Group Pass
+# GO Train Group Pass Coordinator
 
 [![Lint and Type Check](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/lint.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/lint.yml)
 [![Accessibility Audit](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/accessibility.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/accessibility.yml)
 [![Security Audit](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/security.yml/badge.svg)](https://github.com/CivicTechWR/go-train-group-pass/actions/workflows/security.yml)
 
-Interested in helping out? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for meetup details, setup steps, and collaboration norms.
+**Helping Kitchener-Waterloo commuters save money and stay safe by coordinating GO Transit group passes**
+
+-----
+
+## 🚨 We Need Frontend Help
+
+Our backend is built and working, but we have **no user interface yet**. We’re looking for frontend developers (or people willing to learn React/Next.js) to help build the web app. See [Contributing](#contributing) for details.
+
+-----
+
+## The Problem
+
+GO Transit offers [Weekday Group Passes](https://www.gotransit.com/en/partners-and-promotions/weekday-group-passes) that let 2-5 people travel together all day for a flat rate (starting at $30). They’re a great deal—but coordinating with strangers via WhatsApp groups is messy and risky:
+
+- Hard to find people traveling your route at your time
+- Chaotic group chats with last-minute dropouts
+- Awkward money collection and pass sharing
+- **Your phone number gets exposed to strangers** - creating risk of stalking or unwanted contact
+- No way to verify who’s actually showing up
+
+This app fixes that by making group coordination simple, reliable, transparent, and **private**. Only the ticket steward (pass purchaser) shares their contact info—everyone else can stay anonymous.
 
 ## Product Overview
 
-Go Train Group Pass is a civic-tech collaboration that streamlines the purchase and coordination of GO Transit group passes. The platform exposes authenticated APIs, GTFS-powered data services, and admin tools that downstream web or mobile clients use to help riders plan trips, manage eligibility, and share passes across a group.
+Go Train Group Pass is a civic-tech collaboration that streamlines the purchase and coordination of GO Transit group passes. The platform provides authenticated APIs, GTFS-powered schedule data, and coordination tools that help riders plan trips, form groups, and share passes safely.
 
 - [Technical Design Document (Notion, WIP)](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9)
 - [Product and UX boards (Figma)](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1)
@@ -16,17 +36,96 @@ Go Train Group Pass is a civic-tech collaboration that streamlines the purchase 
 ### Product Principles
 
 - **Support stewards, not replace them:** The app augments the existing steward-led process and does not referee peer-to-peer payments.
-- **Time-sensitive coordination:** Clear status cues are core to keeping the group aligned in the minutes leading up to boarding and while on the train.
+- **Privacy by design:** Only the ticket steward shares contact information. Other group members stay anonymous until they choose otherwise.
+- **Time-sensitive coordination:** Clear status cues keep the group aligned in the minutes leading up to boarding and while on the train.
 - **Clarity over chat scrollback:** Interfaces focus on surfacing the current itinerary state rather than relying on ad-hoc messaging threads.
+
+## What We’re Building
+
+A web app where commuters can:
+
+1. **Find travel partners** - Search for people going your route at your time
+1. **Form groups automatically** - Get matched with compatible travelers (2-5 people)
+1. **Coordinate meetups** - Agree on meeting spot, confirm arrival
+1. **Protect your privacy** - Only the ticket steward (pass purchaser) shares contact info
+1. **Handle the pass** - One person buys, everyone gets proof of group membership
+1. **Split costs fairly** - Track who owes what (payment happens outside the app for now)
+
+## Current Status & Roadmap
 
 ### Rider Journey Stages
 
-The stages below map to open issues in this repository:
+The stages below map to open issues and our development epics:
 
-1. **Pre-board (MVP):** Group formation, check-in, QR/scan, and steward confirmations ([#67–71](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+67..71), [#93–100](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+93..100), [#104–110](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+104..110)).
-2. **On board (MVP):** Steward tools for verification and regrouping (same issue sets as above).
-3. **Pre-planning (Planned):** Trip search and itinerary creation ([#64–66](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+64..66), [#74–86](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+74..86)).
-4. **Post board (Planned):** Ticket purchase, cost splits, and payments/reconciliation ([#72–73](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+72..73), [#107–115](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+107..115)).
+#### 1. Pre-planning (Epic 1: Trip Discovery & Planning - 70% done)
+
+Search schedules, create itineraries, plan your trips
+
+- ✅ GTFS data import and refresh
+- ✅ One-way trip schedule search
+- ✅ Round-trip Kitchener-Union query
+- 🔄 Generic round-trip endpoint
+- 🔄 Itinerary creation flow
+- Issues: [#64–66](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+64..66), [#74–86](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+74..86)
+
+#### 2. Pre-board - MVP Priority
+
+**Epic 2: Group Formation & Matching (40% done)**  
+**Epic 3: Group Coordination (0% done)**
+
+Group formation, check-in, QR/scan, and steward confirmations
+
+- ✅ Database schema (travel_group, trip_booking)
+- ✅ Group formation background job
+- 🔄 Manual group formation trigger
+- ❌ Group chat/messaging
+- ❌ Meetup location selection
+- ❌ Member check-in status
+- ❌ **Frontend interface** (blocking everything)
+- Issues: [#67–71](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+67..71), [#93–100](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+93..100), [#104–110](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+104..110)
+
+#### 3. On board - MVP Priority
+
+**Epic 3: Group Coordination (continued)**
+
+Steward tools for verification and regrouping
+
+- ❌ Active pass display
+- ❌ Real-time group status
+- ❌ Steward broadcast tools
+- Issues: Same as Pre-board
+
+#### 4. Post board
+
+**Epic 4: Pass Purchase & Activation (20% done)**  
+**Epic 5: Payment Settlement (0% done)**
+
+Ticket purchase, cost splits, and payments/reconciliation
+
+- ✅ Database schema (ticket_purchase, payment tables)
+- ❌ Pass purchase workflow
+- ❌ Cost calculation & display
+- ❌ Payment tracking
+- Issues: [#72–73](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+72..73), [#107–115](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+107..115)
+
+### Additional Epics (Not Started)
+
+**Epic 6: Notifications & Alerts (0% done)**
+
+- Trip reminders, group updates, service disruptions
+- Critical for user adoption post-MVP
+
+**Epic 7: User Experience / Frontend (0% done) ⚠️ BLOCKING**
+
+- Web interface - without this, nothing else matters
+- Issues: [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26), [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)
+
+**Epic 8: Safety & Trust (0% done)**
+
+- User verification, reporting, blocking, moderation
+- Can defer to post-MVP but important for scale
+
+### System Architecture
 
 ```mermaid
 flowchart LR
@@ -53,55 +152,117 @@ flowchart LR
 
 ## Technology Stack
 
-- **Backend:** NestJS 11 (Fastify adapter), TypeScript, MikroORM (PostgreSQL)
-- **Authentication:** Supabase Auth (JWT session tokens)
-- **Data Source:** GO Transit GTFS feeds mapped into Supabase PostgreSQL 17
-- **Frontend (planned):** Next.js + React web client (see issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52))
-- **Tooling:** ESLint, Prettier, Vitest, SWC, ts-node
-- **Automation:** GitHub Actions for linting, accessibility audits, and security scans
+**Backend (completed):**
+
+- NestJS 11 (Fastify adapter), TypeScript
+- PostgreSQL + MikroORM
+- Supabase Auth (JWT session tokens)
+- GTFS transit data processing
+
+**Frontend (planned - need help!):**
+
+- Next.js 14+ (App Router)
+- React + TypeScript
+- Tailwind CSS (or your preference)
+- Real-time updates (WebSockets or polling)
+
+**Tooling:**
+
+- ESLint, Prettier, Vitest, SWC, ts-node
+- GitHub Actions for linting, accessibility audits, and security scans
 
 Reference: `backend/package.json` and [`backend/README.md`](backend/README.md#tech-stack).
 
-## Architecture Overview
-
-- High-level flow: the Mermaid chart above captures rider, platform, and Supabase interactions. The broader MVP coordination stages live in the Technical Design Document linked in the Product Overview.
-- Backend modules and entities are documented in [`backend/README.md`](backend/README.md#project-structure) and [`backend/AUTH_SETUP.md`](backend/AUTH_SETUP.md#architecture).
-- Supabase infrastructure and local parity live in [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md).
-
 ## Getting Started
 
-Follow the guide for the area you plan to work on:
+Interested in helping out? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for meetup details, setup steps, and collaboration norms.
 
-| Surface            | Status       | Setup Guide                                                                                                                                                    |
-| ------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Backend API        | Active       | [`backend/README.md#getting-started`](backend/README.md#getting-started)                                                                                       |
-| Supabase stack     | Active       | [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md)                                                                                                       |
-| Frontend (Next.js) | Planned      | Track via issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52); setup docs will follow |
+### Quick Start for Developers
+
+**Prerequisites:**
+
+- Node.js 18+ and npm
+- PostgreSQL (or use our Supabase setup)
+- Basic familiarity with REST APIs
+
+**Get the backend running:**
+
+```bash
+git clone https://github.com/CivicTechWR/go-train-group-pass.git
+cd go-train-group-pass
+npm install
+cd backend
+npm run dev
+```
+
+See detailed setup guides:
+
+|Surface           |Status |Setup Guide                                                                                                                                                 |
+|------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|Backend API       |Active |[`backend/README.md#getting-started`](backend/README.md#getting-started)                                                                                    |
+|Supabase stack    |Active |[`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md)                                                                                                    |
+|Frontend (Next.js)|Planned|Track via issues [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26) and [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)|
+
+**Want to build the frontend?** Talk to us first! We’ll help you:
+
+- Understand the API endpoints
+- Set up your development environment
+- Get access to our Figma designs
+- Connect with the team
 
 ## Project Structure
 
 - **`backend/`** — NestJS application modules, MikroORM entities, and Vitest suites. See [`backend/README.md#project-structure`](backend/README.md#project-structure) for file-level detail.
+- **`packages/shared/`** — Shared TypeScript types and DTOs
 - **`supabase/`** — Local Supabase configuration (CLI, database, auth) that mirrors hosted infrastructure.
+- **`spec/`** — Technical specifications and process documentation
 - **`.github/workflows/`** — Automation pipelines for linting, accessibility, and security checks that gate pull requests.
-- **UX & product specs** — Living documents in [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9#2a1e01ee4c00805b9432d69102af7a43) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) capture workflows and visual design decisions that have not yet landed in this repo.
+- **UX & product specs** — Living documents in [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) capture workflows and visual design decisions.
 
-## Key Features
+Frontend will go in a new folder (we need someone to set it up!)
 
-### Current state (in repo)
+## Contributing
 
-- Supabase-authenticated REST endpoints for signup/signin/refresh/password flows (`backend/src/auth`).
-- GTFS data models defined via MikroORM entities (`backend/src/entities`), ready for ingestion and API layers.
-- CI workflows for linting, accessibility smoke tests, and security scans (see badges above).
+We welcome contributors of all skill levels:
 
-### Planned/backlog (open issues)
+- **Frontend Developers (URGENT NEED):** React/Next.js experience to build the user interface
+- **Backend Developers:** Help finish APIs, improve testing, optimize queries
+- **Designers:** UX/UI, user research, accessibility design
+- **Testers:** QA, user testing, feedback on flows
+- **Writers:** Documentation, help content, privacy policies
+- **Anyone interested:** Come learn with us!
 
-- Trip search and itinerary creation APIs: [#64–66](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+64..66), [#74–86](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+74..86)
-- Group formation, check-in, steward views, QR/scan, and confirmations: [#67–71](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+67..71), [#93–100](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+93..100), [#104–110](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+104..110)
-- Ticket purchase, cost split, payments, and mark-paid flows: [#72–73](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+72..73), [#107–115](https://github.com/CivicTechWR/go-train-group-pass/issues?q=is%3Aissue+is%3Aopen+107..115)
-- GTFS ingestion and schedule import: [#3](https://github.com/CivicTechWR/go-train-group-pass/issues/3), [#13](https://github.com/CivicTechWR/go-train-group-pass/issues/13)
-- Frontend Next.js/React app and hosting decisions: [#26](https://github.com/CivicTechWR/go-train-group-pass/issues/26), [#27](https://github.com/CivicTechWR/go-train-group-pass/issues/27), [#52](https://github.com/CivicTechWR/go-train-group-pass/issues/52)
+### Time Commitment
 
-Refer to the [Technical Design Document](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) for the broader roadmap; keep the README aligned with open issues when adding new commitments.
+- **90-120 minutes/week** at Wednesday hack nights
+- More if you want to contribute outside of meetups
+- Even occasional contributions (once a month) are valuable
+
+### Why Join This Project
+
+- Real impact for local commuters
+- Portfolio piece with actual users
+- Supportive civic tech community
+- Flexible volunteer hours
+- Learn from experienced developers
+
+### How to Get Involved
+
+1. **Join our community:**
+- Slack: [CivicTechWR workspace](https://join.slack.com/t/civictechwr/shared_invite/zt-2hk4c93hv-DEIbxR_z1xKj8cZmayVHTw)
+- Weekly hacknights: [Schedule](https://docs.google.com/spreadsheets/d/1hAxstCyiVBdYeSQlIrlkhnSntJLJ3kNnoCuechFJN7E/edit?gid=0#gid=0)
+1. **Pick an issue or propose a feature:**
+- Look for `good first issue` or `help wanted` labels
+- Comment on the issue to claim it
+- Ask questions if anything is unclear
+1. **Submit your work:**
+- Fork the repo
+- Create a feature branch
+- Follow our code style (Prettier + ESLint configured)
+- Write tests for new features
+- Submit a pull request
+
+Read our [Code of Conduct](CODE_OF_CONDUCT.md) and check out [open issues](https://github.com/CivicTechWR/go-train-group-pass/issues).
 
 ## Development Workflow
 
@@ -121,11 +282,89 @@ Refer to the [Technical Design Document](https://www.notion.so/Technical-Design-
 - A full overview of unit, integration, e2e, coverage, and accessibility testing lives in [`backend/README.md#testing`](backend/README.md#testing) and the associated scripts (`package.json`).
 - CI executes the same commands, including accessibility audits via Playwright + axe (`npm run test:a11y`) and scheduled security scans.
 
-## Contributing
+## Frequently Asked Questions
 
-- Review the [Notion product roadmap](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) and [Figma flows](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) for context before drafting solutions.
-- Use the issue templates to capture requirements; follow the pull-request checklist to surface tests, migrations, and Supabase changes.
-- Reference code patterns in `backend/src` and examples in future `docs/` entries rather than duplicating snippets here, keeping the README evergreen.
+### General Questions
+
+**Q: Why not just keep using WhatsApp groups?**
+
+A: WhatsApp groups expose everyone’s phone number to strangers, making people vulnerable to stalking or unwanted contact. Our app keeps you anonymous—only the ticket steward (who buys the pass) shares their contact info with the group.
+
+**Q: How much does it cost to use?**
+
+A: The app is completely free. You only pay for the GO Transit group pass itself (starting at $30 for 2 people).
+
+**Q: Do I need to download an app?**
+
+A: No! It’s a web app that works in your phone’s browser.
+
+**Q: What if someone doesn’t show up?**
+
+A: The app tracks check-ins and confirmations. If someone doesn’t confirm by a set time before departure, the group can be reformed or you can find a replacement. (This feature is still being built.)
+
+**Q: Who buys the actual GO Transit pass?**
+
+A: One person in the group (the “steward”) purchases the pass from GO Transit. The app helps track who owes money and confirms payment, but the actual money exchange happens outside the app (e-transfer, cash, etc.).
+
+### Privacy & Safety
+
+**Q: What information do other group members see about me?**
+
+A: By default, only your first name and a profile photo (if you add one). Your phone number and email stay private. Only the ticket steward shares their contact info so the group can coordinate.
+
+**Q: What if I get matched with someone I don’t want to travel with?**
+
+A: You can leave a group at any time before the pass is purchased. We’re also building blocking and reporting features.
+
+**Q: How do you prevent fake accounts or bad actors?**
+
+A: We’re implementing user verification (email and/or SMS) and exploring additional trust features like reputation scores and verified user badges. This is part of our Safety & Trust epic (coming after launch).
+
+### Technical Questions
+
+**Q: What happens to my data?**
+
+A: Your data is stored securely in our database. We only collect what’s necessary for the app to work (name, email, travel preferences). We don’t sell your data or share it with third parties. See our privacy policy (coming soon) for details.
+
+**Q: Can I use this for weekend travel?**
+
+A: Currently we’re focused on weekday group passes. Weekend passes work differently (individual $10 day passes), but we might support them in the future.
+
+**Q: Does this work with PRESTO cards?**
+
+A: No, GO Transit’s weekday group passes are only available as e-tickets, not through PRESTO. You buy them online and activate them on your phone.
+
+### For Contributors
+
+**Q: I’m not a developer, can I still help?**
+
+A: Absolutely! We need designers, testers, writers, and people to help with user research. Come to a hacknight and tell us what you’re interested in.
+
+**Q: I’m a beginner, is this project too advanced?**
+
+A: Not at all. We welcome all skill levels. The backend is complex, but we can help you learn. If you’re interested in frontend, we’ll pair you with someone who can guide you.
+
+**Q: What if I can only volunteer occasionally?**
+
+A: That’s totally fine. Even showing up once a month and contributing a feature or bug fix is valuable. We work with people’s schedules.
+
+**Q: Do you have a deadline?**
+
+A: No hard deadline, but we’d love to launch something usable by spring 2025 when commuters are looking for ways to save money after winter.
+
+## About CivicTech Waterloo Region
+
+We’re a volunteer community using technology to solve local problems. We meet weekly for hacknights and monthly speaker sessions. Learn more at [civictechwr.org](https://civictechwr.org/).
+
+## Questions?
+
+- **Slack:** #go-train-group-pass channel in [CivicTechWR workspace](https://join.slack.com/t/civictechwr/shared_invite/zt-2hk4c93hv-DEIbxR_z1xKj8cZmayVHTw)
+- **Issues:** [GitHub Issues](https://github.com/CivicTechWR/go-train-group-pass/issues)
+- **In person:** Come to a hacknight! [See schedule](https://docs.google.com/spreadsheets/d/1hAxstCyiVBdYeSQlIrlkhnSntJLJ3kNnoCuechFJN7E/edit?gid=0#gid=0)
+
+-----
+
+**Ready to help build this?** Start by introducing yourself in our Slack channel or come to the next hacknight. We’d love to have you on the team.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,53 +55,13 @@ A web app where commuters can:
 
 For the latest project status, roadmap, and development progress, see the [Pass Sharing Project](https://github.com/orgs/CivicTechWR/projects/pass-sharing-project).
 
-### System Architecture
-
-```mermaid
-flowchart LR
-    subgraph Riders
-        EndUsers[Group riders]
-    end
-    subgraph CivicTechWR Platform
-        Clients[Web & future mobile apps]
-        API[NestJS + Fastify API]
-        AuthGuard[Supabase Auth integration]
-        Data[GTFS + Pass entities]
-    end
-    subgraph Infrastructure
-        SupabaseAuth[Supabase Auth]
-        SupabaseDB[Supabase PostgreSQL]
-    end
-
-    EndUsers --> Clients --> API
-    API --> AuthGuard
-    AuthGuard --> SupabaseAuth
-    API --> Data --> SupabaseDB
-    SupabaseAuth --> SupabaseDB
-```
-
 ## Technology Stack
 
-**Backend (completed):**
+We use modern TypeScript-based tools for both backend and frontend development.
 
-- NestJS 11 (Fastify adapter), TypeScript
-- PostgreSQL + MikroORM
-- Supabase Auth (JWT session tokens)
-- GTFS transit data processing
-
-**Frontend (planned - need help!):**
-
-- Next.js 14+ (App Router)
-- React + TypeScript
-- Tailwind CSS (or your preference)
-- Real-time updates (WebSockets or polling)
-
-**Tooling:**
-
-- ESLint, Prettier, Vitest, SWC, ts-node
-- GitHub Actions for linting, accessibility audits, and security scans
-
-Reference: `backend/package.json` and [`backend/README.md`](backend/README.md#tech-stack).
+**For complete technology details, system architecture, and tooling information, see:**
+- [`backend/README.md`](backend/README.md) - Backend tech stack, architecture, and project structure
+- `backend/package.json` - Complete list of dependencies and scripts
 
 ## Getting Started
 
@@ -134,12 +94,12 @@ Additional setup guides:
 
 ## Project Structure
 
-- **`backend/`** — Backend API service. See [`backend/README.md#project-structure`](backend/README.md#project-structure) for details.
+- **`backend/`** — Backend API service. See [`backend/README.md`](backend/README.md) for architecture, tech stack, and detailed project structure.
 - **`packages/shared/`** — Shared TypeScript types and DTOs
-- **`supabase/`** — Local Supabase configuration (CLI, database, auth) that mirrors hosted infrastructure.
+- **`supabase/`** — Local Supabase configuration. See [`backend/SUPABASE_SETUP.md`](backend/SUPABASE_SETUP.md) for setup guide.
 - **`spec/`** — Technical specifications and process documentation
-- **`.github/workflows/`** — Automation pipelines for linting, accessibility, and security checks that gate pull requests.
-- **UX & product specs** — Living documents in [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1) capture workflows and visual design decisions.
+- **`.github/workflows/`** — CI/CD automation pipelines
+- **UX & product specs** — [Notion](https://www.notion.so/Technical-Design-Document-WIP-2a1e01ee4c0080a391bfcd52b067f9a9) and [Figma](https://www.figma.com/board/5AhW638DdlgCooNjtEZnEG/Metrolinx-Group-Pass?node-id=0-1&t=e1jtwAZg5bLGRAGI-1)
 
 Frontend will go in a new folder (we need someone to set it up!)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,41 @@ Backend API for the Go Train Group Pass application, built with NestJS, MikroORM
 - **Testing**: Vitest
 - **Language**: TypeScript
 
+## System Architecture
+
+The application follows a layered architecture with clear separation between client, API, and infrastructure layers:
+
+```mermaid
+flowchart LR
+    subgraph Riders
+        EndUsers[Group riders]
+    end
+    subgraph CivicTechWR Platform
+        Clients[Web & future mobile apps]
+        API[NestJS + Fastify API]
+        AuthGuard[Supabase Auth integration]
+        Data[GTFS + Pass entities]
+    end
+    subgraph Infrastructure
+        SupabaseAuth[Supabase Auth]
+        SupabaseDB[Supabase PostgreSQL]
+    end
+
+    EndUsers --> Clients --> API
+    API --> AuthGuard
+    AuthGuard --> SupabaseAuth
+    API --> Data --> SupabaseDB
+    SupabaseAuth --> SupabaseDB
+```
+
+**Key Components:**
+- **API Layer**: NestJS with Fastify adapter handles HTTP requests and business logic
+- **Auth Layer**: Supabase Auth provides JWT-based authentication and user management
+- **Data Layer**: MikroORM entities map to PostgreSQL database for GTFS data and pass coordination
+- **Client Layer**: Future web and mobile applications will consume the REST API
+
+For detailed architectural patterns, see [RepositoryServiceControllerArchitecture.md](./RepositoryServiceControllerArchitecture.md).
+
 ## Prerequisites
 
 Before you begin, ensure you have the following installed:

--- a/docs/gitleaks-response.md
+++ b/docs/gitleaks-response.md
@@ -1,0 +1,27 @@
+# Gitleaks Response Guide
+
+This document explains the maintainers' recommended steps when the repository's Gitleaks scan flags potential secrets.
+
+1. Triage the finding
+   - Review the redacted report attached to the workflow run or the pull request comment to identify the affected file(s).
+   - Determine whether the exposed value is a secret (API key, token, password) or a false positive.
+
+2. Contain the exposure
+   - If a secret is confirmed, remove it from the repository immediately (revert the change or replace it in a follow-up commit).
+   - Rotate the exposed credential in the relevant service (Supabase, third-party API, etc.).
+
+3. Clean history if needed
+   - If the secret existed in commit history, follow the documented process for removing sensitive data from history (e.g., `git filter-repo` or provider guidance).
+   - Coordinate with maintainers before rewriting shared branch history.
+
+4. Notify maintainers and affected teams
+   - Add a comment to the pull request describing the remediation steps taken and the credential rotation status.
+   - For anything high-risk, email `civictechwr@gmail.com` to escalate privately.
+
+5. Re-run scans
+   - After remediation, re-run the CI scan to confirm no further findings remain.
+
+## Notes
+
+- Gitleaks output is redacted in CI artifacts. Use the attached artifact to inspect findings and avoid pasting secrets into issue comments.
+- This file is intentionally high-level. For step-by-step tooling commands or escalation templates, contact repository maintainers.


### PR DESCRIPTION
## Summary
- refresh the top-level README with current backend architecture and workflows
- introduce a project-specific `CONTRIBUTING.md` with meetup cadence, semantic commits, and contact details
- add reusable GitLeaks workflow assets (response guide + CI spec) to remove broken doc links

## Testing
- not applicable
