### PR TITLE
fix: add HttpExceptionFilter to handle exceptions with nodenext module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,15 +5,20 @@ import { AppConfigModule } from './modules/config.module';
 import { OrmModule } from './modules/orm.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { GtfsModule } from './gtfs/gtfs.module';
-import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { ResponseSerializeInterceptor } from './common/interceptors/response.interceptor';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 @Module({
   imports: [AppConfigModule, OrmModule, AuthModule, GtfsModule],
   controllers: [AppController],
   providers: [
     AppService,
+    {
+      provide: APP_FILTER,
+      useClass: HttpExceptionFilter,
+    },
     {
       provide: APP_INTERCEPTOR,
       useClass: ResponseSerializeInterceptor,

--- a/backend/src/common/filters/http-exception.filter.ts
+++ b/backend/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,48 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { FastifyReply } from 'fastify';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<FastifyReply>();
+
+    // Check if it's an HttpException by trying to get status
+    // This works even if instanceof fails due to module resolution issues
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message: string | string[] = 'Internal server error';
+
+    if (
+      exception &&
+      typeof exception === 'object' &&
+      'getStatus' in exception &&
+      typeof (exception as { getStatus: unknown }).getStatus === 'function'
+    ) {
+      // It's an HttpException (or has the same interface)
+      const httpException = exception as HttpException;
+      status = httpException.getStatus();
+
+      const exceptionResponse = httpException.getResponse();
+      message =
+        typeof exceptionResponse === 'string'
+          ? exceptionResponse
+          : (exceptionResponse as { message?: string | string[] })?.message ||
+            httpException.message ||
+            'Internal server error';
+    } else if (exception instanceof Error) {
+      // It's a regular Error - log it but don't expose details in production
+      message = exception.message || 'Internal server error';
+    }
+
+    response.status(status).send({
+      statusCode: status,
+      message: Array.isArray(message) ? message[0] : message,
+    });
+  }
+}


### PR DESCRIPTION
Following up on https://github.com/CivicTechWR/go-train-group-pass/pull/39#issuecomment-3621404909

> Keep the branch @jliu1016. Apparently there's a change that broke NestJS exception handler. Investigating...
> 
> TL;DR NestJS exception handler is broken. For example, HTTP Exceptions like 401, 400, and 404 are no longer handled correctly by Nest, responding only with:
> 
> ```json
> {
>   "statusCode": 500,
>   "message": "Internal server error"
> }
> ```
> 
> Update 1: Culprit commit identified [d5b78a8](https://github.com/CivicTechWR/go-train-group-pass/commit/d5b78a8dd82ba56b5b619ca9f1c4e130fcc80453) `update backend configs to work with new shared package by using webpack, update auth service to use shared dtos`
> 
> Update 2: Root Cause: Commit [d5b78a8](https://github.com/CivicTechWR/go-train-group-pass/commit/d5b78a8dd82ba56b5b619ca9f1c4e130fcc80453) changed TypeScript module settings from "module": "commonjs" to "module": "nodenext" and "moduleResolution": "nodenext". The nodenext resolution can create separate module instances, causing instanceof HttpException checks in NestJS's built-in exception filter to fail. This made exceptions appear as unhandled errors, resulting in 500 responses. However, reverting tsconfig.json would break the shared package implementation.

HTTP exceptions were returning 500 instead of correct status codes due to instanceof checks failing with nodenext module resolution.
Solution: Added HttpExceptionFilter that uses duck typing (getStatus()) instead of instanceof, ensuring proper exception handling while maintaining nodenext settings for shared package support.
Verified: exceptions now return correct status codes (401, 400, etc.) without breaking existing functionality.