### PR TITLE
refactor(shared): move internal UserMetadataSchema to backend

### DIFF
--- a/backend/src/modules/auth/auth.schemas.ts
+++ b/backend/src/modules/auth/auth.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Schema representing Supabase's internal user metadata format.
+ * Uses snake_case to match Supabase's convention.
+ *
+ * This is used when:
+ * - Sending user metadata to Supabase during signup
+ * - Reading user metadata back from Supabase
+ *
+ * Note: This is intentionally kept in the backend only, as the frontend
+ * should use the public API schemas (camelCase) from @go-train-group-pass/shared.
+ */
+export const UserMetadataSchema = z.object({
+  full_name: z.string(),
+  phone_number: z.string(),
+});
+
+export type UserMetadata = z.infer<typeof UserMetadataSchema>;

--- a/packages/shared/src/auth/auth.schemas.ts
+++ b/packages/shared/src/auth/auth.schemas.ts
@@ -1,10 +1,5 @@
 import { z } from 'zod';
 
-export const UserMetadataSchema = z.object({
-  full_name: z.string(),
-  phone_number: z.string(),
-});
-
 export const SignUpInputSchema = z.object({
   email: z.email('Invalid email address'),
   password: z


### PR DESCRIPTION
## Summary

Moves `UserMetadataSchema` from the shared package to the backend, where it belongs as an internal schema for Supabase communication.

### What changed:

1. **Removed** `UserMetadataSchema` from `packages/shared/src/auth/auth.schemas.ts`
2. **Added** `UserMetadataSchema` to `backend/src/modules/auth/auth.schemas.ts`

### Why move this schema:

1. **Internal Supabase format** — Uses snake_case naming (`full_name`, `phone_number`) which is Supabase's internal metadata convention, not the public API contract which uses camelCase (`fullName`, `phoneNumber`)

2. **Backend-only concern** — The frontend uses `SignUpInputSchema` (camelCase) and never needs to know about Supabase's internal format

3. **Still useful for backend** — Provides type safety when communicating with Supabase Auth (signup, reading user metadata, etc.)

### Schemas that remain shared (and should stay shared):

All other schemas define the API contract between frontend and backend:
- `SignUpInputSchema`, `SignInInputSchema` — Form validation
- `PasswordResetInputSchema`, `PasswordUpdateInputSchema`, `PasswordResetResponseSchema` — Password flows
- `RefreshTokenSchema` — Token refresh
- `UserSchema`, `AuthResponseSchema` — Response shapes

These are legitimately needed by the frontend for form validation and type safety.

## Test Plan

- [x] Verified schema is not imported from shared anywhere
- [x] CI passes (lint, type-check)

Closes #122