### PR TITLE
Feature/116 aggregated itineraries view

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { TripModule } from './trip/trip.module';
 import { TripBookingModule } from './trip-booking/trip-booking.module';
 import { TripScheduleModule } from './trip-schedule/trip-schedule.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { ItinerarySubscriber } from './subscribers/itinerary.subscriber';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
       provide: APP_PIPE,
       useClass: ZodValidationPipe,
     },
+    ItinerarySubscriber,
   ],
 })
 export class AppModule {}

--- a/backend/src/database/migrations/.snapshot-postgres.json
+++ b/backend/src/database/migrations/.snapshot-postgres.json
@@ -1811,6 +1811,16 @@
           "default": "false",
           "mappedType": "boolean"
         },
+        "trip_hash": {
+          "name": "trip_hash",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        },
         "user_id": {
           "name": "user_id",
           "type": "uuid",

--- a/backend/src/database/migrations/Migration20251209034629.ts
+++ b/backend/src/database/migrations/Migration20251209034629.ts
@@ -1,0 +1,23 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20251209034629 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "go-train-group-pass"."itinerary" add column "trip_hash" varchar(255) null;`);
+
+    this.addSql(`
+      UPDATE "go-train-group-pass"."itinerary" i
+      SET trip_hash = (
+          SELECT md5(STRING_AGG(tb.trip_id::text, ',' ORDER BY tb.sequence))
+          FROM "go-train-group-pass"."trip_booking" tb
+          WHERE tb.itinerary_id = i.id
+      )
+      WHERE trip_hash IS NULL;
+    `);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "go-train-group-pass"."itinerary" drop column "trip_hash";`);
+  }
+
+}

--- a/backend/src/entities/aggregated_itinerary.entity.ts
+++ b/backend/src/entities/aggregated_itinerary.entity.ts
@@ -1,38 +1,36 @@
 import { Entity, Property } from '@mikro-orm/core';
-import { TripDetailsSchema } from '@go-train-group-pass/shared';
-import z from 'zod';
+import { TripDetailsDto } from '@go-train-group-pass/shared';
 
 @Entity({
   expression: `
-    WITH itinerary_sequences AS (
+    WITH clustered_itineraries AS (
       SELECT
-        tb.itinerary_id,
-        i.user_id,
-        STRING_AGG(tb.trip_id::text, ',' ORDER BY tb.sequence) as trip_sequence,
-        json_agg(
-            json_build_object(
-                'tripId', t.id,
-                'orgStation', t.origin_stop_name,
-                'destStation', t.destination_stop_name,
-                'departureTime', t.departure_time,
-                'arrivalTime', t.arrival_time,
-                'routeShortName', t.route_short_name,
-                'sequence', tb.sequence
-            ) ORDER BY tb.sequence
-        ) as trip_details
-      FROM "go-train-group-pass".trip_booking tb
-      JOIN "go-train-group-pass".itinerary i ON i.id = tb.itinerary_id
-      JOIN "go-train-group-pass".trip t ON t.id = tb.trip_id
-      WHERE tb.itinerary_id IS NOT NULL
-      GROUP BY tb.itinerary_id, i.user_id
+        trip_hash,
+        COUNT(DISTINCT user_id)::integer as user_count,
+        MAX(id::text)::uuid as sample_itinerary_id
+      FROM "go-train-group-pass".itinerary
+      WHERE trip_hash IS NOT NULL
+      GROUP BY trip_hash
     )
     SELECT
-      md5(trip_sequence) as id,
-      trip_sequence,
-      COUNT(DISTINCT user_id)::integer as user_count,
-      CAST(MAX(CAST(trip_details AS text)) AS json) as trip_details
-    FROM itinerary_sequences
-    GROUP BY trip_sequence
+      ci.trip_hash as id,
+      ci.user_count,
+      STRING_AGG(tb.trip_id::text, ',' ORDER BY tb.sequence) as trip_sequence,
+      json_agg(
+          json_build_object(
+              'tripId', t.id,
+              'orgStation', t.origin_stop_name,
+              'destStation', t.destination_stop_name,
+              'departureTime', t.departure_time,
+              'arrivalTime', t.arrival_time,
+              'routeShortName', t.route_short_name,
+              'sequence', tb.sequence
+          ) ORDER BY tb.sequence
+      ) as trip_details
+    FROM clustered_itineraries ci
+    JOIN "go-train-group-pass".trip_booking tb ON tb.itinerary_id = ci.sample_itinerary_id
+    JOIN "go-train-group-pass".trip t ON t.id = tb.trip_id
+    GROUP BY ci.trip_hash, ci.user_count
   `,
 })
 export class AggregatedItinerary {
@@ -46,5 +44,5 @@ export class AggregatedItinerary {
   userCount: number;
 
   @Property({ type: 'json' })
-  tripDetails: z.infer<typeof TripDetailsSchema>[];
+  tripDetails: TripDetailsDto[];
 }

--- a/backend/src/entities/itinerary.entity.ts
+++ b/backend/src/entities/itinerary.entity.ts
@@ -24,6 +24,9 @@ export class Itinerary extends BaseEntity {
   @Property({ type: 'boolean', default: false })
   wantsToSteward: boolean;
 
+  @Property({ nullable: true })
+  tripHash?: string;
+
   @ManyToOne(() => User, {
     index: true,
   })

--- a/backend/src/itineraries/itineraries.controller.ts
+++ b/backend/src/itineraries/itineraries.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   Post,
   Request,
   UnauthorizedException,
@@ -13,6 +14,9 @@ import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Serialize } from '../common/decorators/serialize.decorator';
 import {
   CreateItineraryDto,
+  ExistingItinerariesDto,
+  ExistingItinerariesSchema,
+  ItineraryCreationResponseDto,
   ItineraryCreationResponseSchema,
 } from '@go-train-group-pass/shared';
 
@@ -31,10 +35,18 @@ export class ItinerariesController {
   async create(
     @Request() req: RequestWithUser,
     @Body() createItineraryDto: CreateItineraryDto,
-  ) {
+  ): Promise<ItineraryCreationResponseDto> {
     if (!req.user) {
       throw new UnauthorizedException('User not found');
     }
     return this.itinerariesService.create(req.user.id, createItineraryDto);
+  }
+
+  @Get('existing')
+  @ApiOperation({ summary: 'Summary of all itineraries with same trips' })
+  @ApiOkResponse({ description: 'Existing itineraries' })
+  @Serialize(ExistingItinerariesSchema)
+  async getExistingItineraries(): Promise<ExistingItinerariesDto> {
+    return this.itinerariesService.getExistingItineraries();
   }
 }

--- a/backend/src/itineraries/itineraries.module.ts
+++ b/backend/src/itineraries/itineraries.module.ts
@@ -6,10 +6,11 @@ import { Itinerary } from '../entities/itinerary.entity';
 import { AuthModule } from '../modules/auth/auth.module';
 import { UsersModule } from 'src/users/users.module';
 import { TripBookingModule } from 'src/trip-booking/trip-booking.module';
+import { AggregatedItinerary } from 'src/entities';
 
 @Module({
   imports: [
-    MikroOrmModule.forFeature([Itinerary]),
+    MikroOrmModule.forFeature([Itinerary, AggregatedItinerary]),
     UsersModule,
     AuthModule,
     TripBookingModule,

--- a/backend/src/itineraries/itineraries.service.ts
+++ b/backend/src/itineraries/itineraries.service.ts
@@ -2,17 +2,23 @@ import { Injectable } from '@nestjs/common';
 import { EntityRepository, Transactional } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Itinerary } from '../entities/itinerary.entity';
-import { CreateItineraryDto } from '@go-train-group-pass/shared';
+import {
+  CreateItineraryDto,
+  ExistingItinerariesDto,
+} from '@go-train-group-pass/shared';
 import { ItineraryStatus } from '../entities/itineraryStatusEnum';
 import { TripBookingService } from '../trip-booking/trip-booking.service';
 import { UsersService } from '../users/users.service';
 import { ItineraryCreationResponseDto } from '@go-train-group-pass/shared';
+import { AggregatedItinerary } from 'src/entities';
 
 @Injectable()
 export class ItinerariesService {
   constructor(
     @InjectRepository(Itinerary)
     private readonly itineraryRepo: EntityRepository<Itinerary>,
+    @InjectRepository(AggregatedItinerary)
+    private readonly aggregatedItineraryRepo: EntityRepository<AggregatedItinerary>,
     private readonly userService: UsersService,
     private readonly tripBookingService: TripBookingService,
   ) {}
@@ -70,5 +76,14 @@ export class ItinerariesService {
       ),
       stewarding: itinerary.wantsToSteward,
     };
+  }
+
+  // demo only
+  async getExistingItineraries(): Promise<ExistingItinerariesDto> {
+    const aggregatedItineraries = await this.aggregatedItineraryRepo.findAll();
+    return aggregatedItineraries.map((aggregatedItinerary) => ({
+      userCount: aggregatedItinerary.userCount,
+      tripDetails: aggregatedItinerary.tripDetails,
+    }));
   }
 }

--- a/backend/src/subscribers/itinerary.subscriber.ts
+++ b/backend/src/subscribers/itinerary.subscriber.ts
@@ -1,0 +1,32 @@
+import { EntityName, EventArgs, EventSubscriber } from '@mikro-orm/core';
+import { Itinerary } from '../entities/itinerary.entity';
+import { createHash } from 'crypto';
+
+export class ItinerarySubscriber implements EventSubscriber<Itinerary> {
+  getSubscribedEntities(): EntityName<Itinerary>[] {
+    return [Itinerary];
+  }
+
+  async beforeCreate(args: EventArgs<Itinerary>): Promise<void> {
+    this.updateTripHash(args.entity);
+  }
+
+  async beforeUpdate(args: EventArgs<Itinerary>): Promise<void> {
+    this.updateTripHash(args.entity);
+  }
+
+  private updateTripHash(itinerary: Itinerary): void {
+    if (
+      itinerary.tripBookings.isInitialized() &&
+      itinerary.tripBookings.length > 0
+    ) {
+      // Sort bookings by sequence
+      const sortedBookings = itinerary.tripBookings
+        .getItems()
+        .sort((a, b) => (a.sequence || 0) - (b.sequence || 0));
+
+      const tripIds = sortedBookings.map((b) => b.trip.id).join(',');
+      itinerary.tripHash = createHash('md5').update(tripIds).digest('hex');
+    }
+  }
+}

--- a/backend/src/subscribers/itinerary.subscriber.ts
+++ b/backend/src/subscribers/itinerary.subscriber.ts
@@ -7,11 +7,11 @@ export class ItinerarySubscriber implements EventSubscriber<Itinerary> {
     return [Itinerary];
   }
 
-  async beforeCreate(args: EventArgs<Itinerary>): Promise<void> {
+  beforeCreate(args: EventArgs<Itinerary>) {
     this.updateTripHash(args.entity);
   }
 
-  async beforeUpdate(args: EventArgs<Itinerary>): Promise<void> {
+  beforeUpdate(args: EventArgs<Itinerary>) {
     this.updateTripHash(args.entity);
   }
 

--- a/backend/vitest.e2e.config.ts
+++ b/backend/vitest.e2e.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     resolve: {
         alias: {
             '@': resolve(__dirname, './src'),
+            'src': resolve(__dirname, './src'),
+            '@go-train-group-pass/shared': resolve(__dirname, '../packages/shared/src'),
         },
     },
 });

--- a/packages/shared/src/itinerary/itinerary.dto.ts
+++ b/packages/shared/src/itinerary/itinerary.dto.ts
@@ -1,5 +1,7 @@
-import { ItineraryCreationResponseSchema, CreateItinerarySchema } from "./itinerary.schemas";
+import { ItineraryCreationResponseSchema, CreateItinerarySchema, ExistingItinerariesSchema, ExistingItinerarySchema } from "./itinerary.schemas";
 import { createZodDto } from "nestjs-zod";
 
 export class ItineraryCreationResponseDto extends createZodDto(ItineraryCreationResponseSchema) {}
 export class CreateItineraryDto extends createZodDto(CreateItinerarySchema) {}
+export class ExistingItinerariesDto extends createZodDto(ExistingItinerariesSchema) {}
+export class ExistingItineraryDto extends createZodDto(ExistingItinerarySchema) {}

--- a/packages/shared/src/itinerary/itinerary.schemas.ts
+++ b/packages/shared/src/itinerary/itinerary.schemas.ts
@@ -19,3 +19,9 @@ export const CreateItinerarySchema = z.object({
   wantsToSteward: z.boolean(),
 });
 
+export const ExistingItinerarySchema = z.object({
+  userCount: z.number(),
+  tripDetails: z.array(TripDetailsSchema),
+});
+
+export const ExistingItinerariesSchema = z.array(ExistingItinerarySchema);


### PR DESCRIPTION
# Pull Request

## 📋 Description
Grabs itineraries grouped by ones with the exact same sequence of trips. Returns info necessary to populate demo summary. Very unideal endpoint - ideally, in future, we will provide filtering based on trip criteria. For now, this will suffice as the frontend limits these trips to only Kitchener and Union anyway.