### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -25,10 +25,10 @@ jobs:
       NEXT_PUBLIC_ENABLE_DEMO_PAGE: 'false'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,10 +24,10 @@ jobs:
       NEXT_PUBLIC_ENABLE_DEMO_PAGE: 'false'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/reusable-gitleaks.yml
+++ b/.github/workflows/reusable-gitleaks.yml
@@ -34,7 +34,7 @@ jobs:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE || secrets.gitleaks_license || '' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Add pull request comment
         if: ${{ steps.summarize.outputs.found == 'true' && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           LEAK_COUNT: ${{ steps.summarize.outputs.count }}
           RESPONSE_GUIDE_URL: ${{ env.RESPONSE_GUIDE_URL }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload redacted report
         if: ${{ steps.summarize.outputs.found == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gitleaks-report
           path: gitleaks-report.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,10 +38,10 @@ jobs:
       NEXT_PUBLIC_ENABLE_DEMO_PAGE: 'false'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v4 → v6
- Bumps `actions/setup-node` v4 → v6
- Bumps `actions/upload-artifact` v4 → v7 (reusable-gitleaks)
- Bumps `actions/github-script` v7 → v9 (reusable-gitleaks)

## Why

GitHub is deprecating Node.js 20 as the runner for GitHub Actions:
- **June 16, 2026** — Node.js 24 becomes the default; Node.js 20 actions may break
- **September 16, 2026** — Node.js 20 removed from runners entirely

All four workflows were generating the deprecation warning. No functional changes — action APIs are backwards compatible within their major version ranges.

## Test plan

- [ ] Lint and Type Check passes
- [ ] Accessibility Audit passes
- [ ] Security Audit passes
- [ ] No deprecation warnings in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)