### PR TITLE
devops: add CODEOWNERS for automatic reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# CODEOWNERS
+# Assigns default reviewers for pull requests based on file paths.
+# The last matching rule takes precedence.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global fallback — organizers review anything not matched below
+* @BreakableHoodie @adinschmidt @jliu1016
+
+# Backend
+/backend/ @BreakableHoodie @adinschmidt @jliu1016
+
+# Frontend
+/frontend/ @BreakableHoodie @Mosaab-Emam
+
+# Shared types/DTOs — both frontend and backend owners
+/packages/ @BreakableHoodie @adinschmidt @jliu1016 @Mosaab-Emam
+
+# Database migrations — require careful review
+/backend/src/database/migrations/ @BreakableHoodie @adinschmidt @jliu1016
+
+# CI/CD and workflows
+/.github/ @BreakableHoodie
+
+# Supabase config
+/supabase/ @BreakableHoodie @adinschmidt


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` to automatically assign reviewers when a PR is opened
- Routes reviews to the right people based on file path rather than relying on manual assignment

## Assignments

| Path | Reviewers |
|---|---|
| `backend/` | BreakableHoodie, adinschmidt, jliu1016 |
| `frontend/` | BreakableHoodie, Mosaab-Emam |
| `packages/` (shared) | All four |
| `backend/src/database/migrations/` | Backend team (extra scrutiny on schema changes) |
| `.github/` | BreakableHoodie |
| `supabase/` | BreakableHoodie, adinschmidt |

## Why

PRs have been sitting without reviewers for extended periods (e.g. #206 was open 9 days). CODEOWNERS ensures the right people are auto-requested on every PR without relying on the author to remember.

Closes #201

## Test plan

- [ ] Open a test PR touching `backend/` and verify correct reviewers are auto-assigned
- [ ] Open a test PR touching `frontend/` and verify correct reviewers are auto-assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)