### PR TITLE
security: require authentication on trip schedule endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# CODEOWNERS
+# Assigns default reviewers for pull requests based on file paths.
+# The last matching rule takes precedence.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global fallback — organizers review anything not matched below
+* @BreakableHoodie @adinschmidt @jliu1016
+
+# Backend
+/backend/ @BreakableHoodie @adinschmidt @jliu1016
+
+# Frontend
+/frontend/ @BreakableHoodie @Mosaab-Emam
+
+# Shared types/DTOs — both frontend and backend owners
+/packages/ @BreakableHoodie @adinschmidt @jliu1016 @Mosaab-Emam
+
+# Database migrations — require careful review
+/backend/src/database/migrations/ @BreakableHoodie @adinschmidt @jliu1016
+
+# CI/CD and workflows
+/.github/ @BreakableHoodie
+
+# Supabase config
+/supabase/ @BreakableHoodie @adinschmidt

--- a/backend/src/trip-schedule/trip-schedule.controller.spec.ts
+++ b/backend/src/trip-schedule/trip-schedule.controller.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/platform-fastify';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { TripScheduleDetailsDto } from '@go-train-group-pass/shared';
+import { AuthGuard } from 'src/modules/auth/auth.guard';
 
 describe('TripScheduleController (Integration)', () => {
   let app: NestFastifyApplication;
@@ -25,7 +26,10 @@ describe('TripScheduleController (Integration)', () => {
           useValue: mockTripScheduleService,
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(AuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     app = module.createNestApplication<NestFastifyApplication>(
       new FastifyAdapter(),
@@ -145,5 +149,59 @@ describe('TripScheduleController (Integration)', () => {
         mockTripScheduleService.getKIToUnionRoundTripSchedule,
       ).toHaveBeenCalledWith(new Date('2025-12-09'));
     });
+  });
+});
+
+describe('TripScheduleController — auth enforcement', () => {
+  let app: NestFastifyApplication;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TripScheduleController],
+      providers: [
+        {
+          provide: TripScheduleService,
+          useValue: {
+            getTripSchedule: vi.fn(),
+            getKIToUnionRoundTripSchedule: vi.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(AuthGuard)
+      .useValue({ canActivate: () => false })
+      .compile();
+
+    app = module.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /trip-schedule/search returns 403 without a valid token', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/trip-schedule/search',
+      query: {
+        orgStation: 'Kitchener GO',
+        destStation: 'Union Station GO',
+        date: '2025-12-09',
+      },
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('GET /trip-schedule/search/round-trip-kitchener-union returns 403 without a valid token', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/trip-schedule/search/round-trip-kitchener-union',
+      query: { date: '2025-12-09' },
+    });
+    expect(response.statusCode).toBe(403);
   });
 });

--- a/backend/src/trip-schedule/trip-schedule.controller.spec.ts
+++ b/backend/src/trip-schedule/trip-schedule.controller.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/platform-fastify';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { TripScheduleDetailsDto } from '@go-train-group-pass/shared';
+import { UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from 'src/modules/auth/auth.guard';
 
 describe('TripScheduleController (Integration)', () => {
@@ -169,7 +170,11 @@ describe('TripScheduleController — auth enforcement', () => {
       ],
     })
       .overrideGuard(AuthGuard)
-      .useValue({ canActivate: () => false })
+      .useValue({
+        canActivate: () => {
+          throw new UnauthorizedException('Authorization header is required');
+        },
+      })
       .compile();
 
     app = module.createNestApplication<NestFastifyApplication>(
@@ -183,7 +188,7 @@ describe('TripScheduleController — auth enforcement', () => {
     await app.close();
   });
 
-  it('GET /trip-schedule/search returns 403 without a valid token', async () => {
+  it('GET /trip-schedule/search returns 401 without a valid token', async () => {
     const response = await app.inject({
       method: 'GET',
       url: '/trip-schedule/search',
@@ -193,15 +198,15 @@ describe('TripScheduleController — auth enforcement', () => {
         date: '2025-12-09',
       },
     });
-    expect(response.statusCode).toBe(403);
+    expect(response.statusCode).toBe(401);
   });
 
-  it('GET /trip-schedule/search/round-trip-kitchener-union returns 403 without a valid token', async () => {
+  it('GET /trip-schedule/search/round-trip-kitchener-union returns 401 without a valid token', async () => {
     const response = await app.inject({
       method: 'GET',
       url: '/trip-schedule/search/round-trip-kitchener-union',
       query: { date: '2025-12-09' },
     });
-    expect(response.statusCode).toBe(403);
+    expect(response.statusCode).toBe(401);
   });
 });

--- a/backend/src/trip-schedule/trip-schedule.controller.ts
+++ b/backend/src/trip-schedule/trip-schedule.controller.ts
@@ -3,8 +3,9 @@ import {
   RoundTripSchema,
   TripScheduleInputDto,
 } from '@go-train-group-pass/shared';
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import {
+  ApiBearerAuth,
   ApiOperation,
   ApiOkResponse,
   ApiTags,
@@ -12,9 +13,12 @@ import {
 } from '@nestjs/swagger';
 import { TripScheduleService } from './trip-schedule.service';
 import { Serialize } from 'src/common/decorators/serialize.decorator';
+import { AuthGuard } from 'src/modules/auth/auth.guard';
 
 @Controller('trip-schedule')
 @ApiTags('Trip Schedule')
+@UseGuards(AuthGuard)
+@ApiBearerAuth()
 export class TripScheduleController {
   constructor(private readonly tripScheduleService: TripScheduleService) {}
 
@@ -29,7 +33,6 @@ export class TripScheduleController {
   })
   @ApiOkResponse({ description: 'Trip schedule for Kitchener-Union' })
   @Serialize(RoundTripSchema)
-  // route doesn't need to be protected because it's public information
   async demoRoundTripKitchenerUnion(
     @Query() queryParams: KitchenerUnionRoundTripScheduleInputDto,
   ) {

--- a/backend/src/trip-schedule/trip-schedule.module.ts
+++ b/backend/src/trip-schedule/trip-schedule.module.ts
@@ -3,9 +3,10 @@ import { TripScheduleController } from './trip-schedule.controller';
 import { TripScheduleService } from './trip-schedule.service';
 import { TripSchedule } from 'src/entities/trip_schedule_entity';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { AuthModule } from 'src/modules/auth/auth.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([TripSchedule])],
+  imports: [MikroOrmModule.forFeature([TripSchedule]), AuthModule],
   controllers: [TripScheduleController],
   providers: [TripScheduleService],
 })


### PR DESCRIPTION
## Summary

- Applies `@UseGuards(AuthGuard)` at the controller class level so all trip schedule routes require a valid Bearer token
- Imports `AuthModule` into `TripScheduleModule` so `AuthGuard` is available as a provider
- Adds `@ApiBearerAuth()` so Swagger UI reflects the auth requirement
- Removes misleading comment that claimed the route needed no protection
- Updates controller spec to override the guard (passthrough) so existing tests continue to pass
- Adds new auth enforcement test suite confirming both endpoints return `403` without a valid token

## Why

The Metrolinx API Access and Use Agreement (§7a) prohibits redistributing Data within your own API or feed. Without auth, these endpoints return GTFS-derived schedule data to any unauthenticated caller, effectively making them a public data feed.

Closes #209

## Test plan

- [ ] Existing trip schedule tests pass (`npm test`)
- [ ] New auth enforcement tests pass (two `403` cases)
- [ ] `tsc --noEmit` passes
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)