### PR TITLE
fix: parse GTFS dates in America/Toronto timezone

### DIFF
--- a/backend/src/entities/trip.entity.ts
+++ b/backend/src/entities/trip.entity.ts
@@ -7,6 +7,7 @@ import {
   Unique,
 } from '@mikro-orm/core';
 import { randomUUID } from 'crypto';
+import { fromZonedTime } from 'date-fns-tz';
 import { GTFSTrip } from './gtfs_trip.entity';
 import { GTFSStopTime } from './gtfs_stop_times.entity';
 import { BaseEntity } from './base';
@@ -31,11 +32,8 @@ export class Trip extends BaseEntity {
     if (!wrap(this.gtfsTrip).isInitialized()) {
       return undefined;
     }
-    // Parse YYYYMMDD from serviceId
     const s = this.gtfsTrip.serviceId;
-    const year = parseInt(s.substring(0, 4), 10);
-    const month = parseInt(s.substring(4, 6), 10) - 1; // JS months are 0-indexed
-    const day = parseInt(s.substring(6, 8), 10);
-    return new Date(year, month, day);
+    const isoDate = `${s.substring(0, 4)}-${s.substring(4, 6)}-${s.substring(6, 8)}T00:00:00`;
+    return fromZonedTime(isoDate, 'America/Toronto');
   }
 }

--- a/backend/src/utils/getDateTimeFromServiceIdGTFSTimeString.ts
+++ b/backend/src/utils/getDateTimeFromServiceIdGTFSTimeString.ts
@@ -13,12 +13,14 @@ export function getDateTimeFromServiceIdGTFSTimeString(
   const extraDays = Math.floor(hours / 24);
   const normalizedHours = hours % 24;
 
+  // gtfsDateStringToDate returns midnight UTC — use UTC methods to avoid
+  // local-timezone getters returning the wrong calendar day on non-UTC servers.
   const resultDate = new Date(date);
-  resultDate.setDate(resultDate.getDate() + extraDays);
+  resultDate.setUTCDate(resultDate.getUTCDate() + extraDays);
 
-  const year = resultDate.getFullYear();
-  const month = String(resultDate.getMonth() + 1).padStart(2, '0');
-  const day = String(resultDate.getDate()).padStart(2, '0');
+  const year = resultDate.getUTCFullYear();
+  const month = String(resultDate.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(resultDate.getUTCDate()).padStart(2, '0');
   const hoursStr = String(normalizedHours).padStart(2, '0');
   const minutesStr = String(minutes).padStart(2, '0');
   const secondsStr = String(seconds).padStart(2, '0');

--- a/backend/src/utils/gtfsDateStringToDate.ts
+++ b/backend/src/utils/gtfsDateStringToDate.ts
@@ -1,7 +1,9 @@
+// Returns midnight UTC for the given YYYYMMDD string.
+// Using Date.UTC avoids new Date(y,m,d) creating a server-local-timezone date,
+// which would be the wrong calendar day on non-UTC servers.
 export function gtfsDateStringToDate(dateStr: string): Date {
   const year = parseInt(dateStr.substring(0, 4));
   const month = parseInt(dateStr.substring(4, 6)) - 1;
   const day = parseInt(dateStr.substring(6, 8));
-  const date = new Date(year, month, day);
-  return date;
+  return new Date(Date.UTC(year, month, day));
 }


### PR DESCRIPTION
## Summary

- `gtfsDateStringToDate` now uses `Date.UTC()` instead of `new Date(year, month, day)` — returns midnight UTC regardless of server timezone
- `getDateTimeFromServiceIdGTFSTimeString` updated to use UTC Date methods (`getUTCDate`, `setUTCDate`, `getUTCFullYear`, `getUTCMonth`) to stay consistent with the UTC-based Date input
- `trip.entity.ts` date getter replaced with `fromZonedTime(..., 'America/Toronto')`, matching the pattern already used elsewhere in the codebase

## Why

`new Date(year, month, day)` creates a date in the **server's local timezone**. On a UTC server this coincidentally works, but on any server running in a non-UTC timezone the calendar date would be wrong:

- `gtfsDateStringToDate('20251209')` on a UTC+5 server → Dec 8 stored to DB (midnight local = previous day UTC)
- `trip.entity.ts` date getter → wrong date returned for GO Transit schedule comparisons

Cloud deployments are typically UTC so this hasn't caused visible issues, but it's a latent bug that would surface in local development on non-UTC machines or any future deployment in a different timezone.

Closes #193
Related to #188 (time audit) and #126 (time handling across the app)

## Test plan

- [ ] Type check passes (`tsc --noEmit`) ✅
- [ ] Lint passes ✅
- [ ] Verify `getDateTimeFromServiceIdGTFSTimeString('20251209', '08:30:00')` returns the correct UTC timestamp for 8:30am Toronto time

🤖 Generated with [Claude Code](https://claude.com/claude-code)