### PR TITLE
fix(security): clear brace-expansion and js-yaml high advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -775,9 +775,9 @@
             }
         },
         "node_modules/@fastify/static/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -1616,9 +1616,9 @@
             }
         },
         "node_modules/@nestjs/cli/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2046,20 +2046,20 @@
             "license": "MIT"
         },
         "node_modules/@nestjs/swagger": {
-            "version": "11.4.4",
-            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
-            "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+            "version": "11.4.6",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.6.tgz",
+            "integrity": "sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "0.16.0",
                 "@nestjs/mapped-types": "2.1.1",
-                "js-yaml": "4.1.1",
+                "js-yaml": "5.2.1",
                 "lodash": "4.18.1",
                 "path-to-regexp": "8.4.2",
-                "swagger-ui-dist": "5.32.6"
+                "swagger-ui-dist": "5.32.8"
             },
             "peerDependencies": {
-                "@fastify/static": "^8.0.0 || ^9.0.0",
+                "@fastify/static": "^8.0.0 || ^9.0.0 || ^10.0.0",
                 "@nestjs/common": "^11.0.1",
                 "@nestjs/core": "^11.0.1",
                 "class-transformer": "*",
@@ -2079,15 +2079,25 @@
             }
         },
         "node_modules/@nestjs/swagger/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+            "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
             "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/@nestjs/testing": {
@@ -3543,9 +3553,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4408,9 +4418,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6372,9 +6382,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6883,9 +6893,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {
@@ -9476,9 +9486,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.32.6",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
-            "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+            "version": "5.32.8",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+            "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "=1.4.0"


### PR DESCRIPTION
## Summary
- `npm audit --audit-level=high` (the `npm-audit (backend)` CI check) is still failing on `main` even after #226 — two new high-severity advisories landed after that PR was authored: `brace-expansion` (GHSA-3jxr-9vmj-r5cp, DoS via exponential expansion) and `js-yaml` via `@nestjs/swagger` (GHSA-52cp-r559-cp3m, quadratic-time merge-key DoS).
- This blocks the npm-audit gate on every backend PR regardless of content — confirmed via [run 27662971407 / job 81810927806](https://github.com/CivicTechWR/go-train-group-pass/actions/runs/27662971407/job/81810927806) on #225, an unrelated Dependabot `vite` bump.
- Resolved via `npm audit fix` (no `--force`, no `package.json` edits): `brace-expansion` → 1.1.16, `js-yaml` → 4.3.0 (5.2.1 under `@nestjs/swagger` 11.4.6), `swagger-ui-dist` patch bump.
- Remaining: 4 moderate `ajv` findings in a dev-tooling chain (`@rushstack/node-core-library` → `@rushstack/terminal` → `@rushstack/ts-command-line`) with no non-breaking fix available yet. They don't trip `--audit-level=high`.

## Test plan
- [x] `npm audit --audit-level=high` exits 0 (verified in an isolated worktree against this lockfile)
- [x] `npm run lint:check` passes
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] `npm run test` — 19/19 tests pass
- [ ] CI green on this PR

## Follow-up
Once merged, PR #225 (and any other Dependabot PRs blocked by this) will need `@dependabot rebase` to pick up the fix, since Dependabot doesn't auto-rebase stale PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdU2fTyzUNpPoUZBaASgGR